### PR TITLE
Experimental: to show you how it works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.vscode
+.code
+.idea
+site/
+venv/
+temp_dir/
+env/
+*.out
+node_modules/
+.DS_Store
+**/.DS_Store
+*.iml

--- a/CONTENT_DISCLAIMER.md
+++ b/CONTENT_DISCLAIMER.md
@@ -1,0 +1,7 @@
+# Polygon Knowledge Layer third-party content disclaimer
+
+The Polygon Knowledge Layer contains third-party content which includes websites, products, and services that are provided for informational purposes only.
+
+Polygon Labs does not endorse, warrant, or make any representations regarding the accuracy, quality, reliability, or legality of any third-party websites, products, or services. If you decide to access any third-party content linked from the Polygon Knowledge Layer, you do so entirely at your own risk and subject to the terms and conditions of use for such websites. Polygon Labs reserves the right to withdraw such references and links without notice.
+
+The Polygon Knowledge Layer serves as an industry public good and is made available under the MIT open source license. In addition, please view the official [Polygon Labs Terms of Use](https://polygon.technology/terms-of-use).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # miden-docs
-Consolidated documentation for the Miden rollup
+
+This is an umbrelle docs repo that will import docs from `miden-base`, `miden-client`, `miden-node`, `miden-compiler`, and `miden-crypto` and more.
+
+Until the satellite branches are published, I cannot test with the Miden docs themselves, so this is a demo currently.
+
+Please see the `mkdocs.yml` file `nav` section and related `plugin` section which shows how you build the navigation menu and import the satellite repos the docs come from.
+
+## Spin up the site
+
+Make sure you have Python 12: `python --version`.
+
+Run the `run.sh` file from the directory root which brings everything up.
+
+Access the local site at http://127.0.0.1:8000/.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,119 @@
+site_name: Miden
+
+theme:
+  name: material
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      primary: white
+      accent: purple
+      toggle:
+        icon: material/eye
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: black
+      accent: purple
+      toggle:
+        icon: material/eye-outline
+        name: Switch to light mode
+  language: en
+  icon:
+    logo: logo
+    repo: repo
+  features:
+    - search.suggest
+    - search.highlight
+    - search.share
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.integration
+    #- navigation.tabs
+    #- navigation.tabs.sticky
+    - navigation.indexes
+    #- navigation.sections
+    - navigation.path
+    - navigation.top
+    - navigation.footer
+    - toc.follow
+    - content.code.copy
+    - content.action.edit
+
+nav:
+  #- Miden client: '!import https://github.com/0xPolygonMiden/miden-client/?branch=main&docs_dir=docs&multi_docs=True&config=mkdocs.yml'
+
+
+plugins:
+  - search
+  - multirepo:
+      # (optional) tells multirepo to cleanup the temporary directory after site is built.
+      cleanup: true
+      # if set the docs directory will not be removed when importing docs. When using this with a nav section in an imported repo
+      # you must keep the docs directory in the path (e.g., docs/path/to/file.md).
+      keep_docs_dir: true
+      repos:
+          # There will be a navigation section with this section name
+        - section: Backstage
+          # you can define the edit uri path
+          import_url: 'https://github.com/backstage/backstage?edit_uri=/blob/master/'
+        - section: Monorepo
+          import_url: 'https://github.com/backstage/mkdocs-monorepo-plugin?edit_uri=/blob/master/'
+        - section: 'Techdocs-cli'
+          # note that the branch is still specified in the url
+          import_url: 'https://github.com/backstage/techdocs-cli?branch=main&edit_uri=/blob/main/'
+        - section: FastAPI
+          import_url: 'https://github.com/tiangolo/fastapi?docs_dir=docs/en/docs/*'
+        - section: Monorepo Multi Docs
+          import_url: https://github.com/backstage/mkdocs-monorepo-plugin?multi_docs=True&docs_dir=sample-docs/*
+        - section: 'Django REST'
+          section_path: python # Put this under the python menu entry
+          import_url: 'https://github.com/encode/django-rest-framework'
+        - section: 'Cookiecutter Pypackage'
+          section_path: python # Put this under the python menu entry
+          import_url: 'https://github.com/zillionare/cookiecutter-pypackage'
+        - section: 'Pydantic'
+          section_path: python # Put this under the python menu entry
+          import_url: 'https://github.com/samuelcolvin/pydantic?branch=main'
+
+markdown_extensions:
+  - toc:
+      permalink: true
+      permalink_title: Link to this section
+      toc_depth: 4
+  - codehilite
+  - markdown_include.include:
+      base_path: docs
+  - admonition
+  - footnotes
+  - def_list
+  - attr_list
+  - abbr
+  - pymdownx.tabbed
+  - pymdownx.superfences
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.keys
+  - pymdownx.details
+  - pymdownx.magiclink
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+  - pymdownx.caret
+  - meta
+  - smarty
+  - pymdownx.extra
+
+extra_javascript:
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.js  
+  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/contrib/auto-render.min.js
+
+extra_css:
+  - https://fonts.googleapis.com/icon?family=Material+Icons
+  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs-material==9.4.8
+markdown-include==0.8.1
+mkdocs-git-revision-date-localized-plugin==1.2.1
+mkdocs-open-in-new-tab==1.0.3
+mkdocs-git-authors-plugin==0.7.2
+mkdocs-multirepo-plugin==0.7.0

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+virtualenv venv
+source venv/bin/activate
+pip3 install -r requirements.txt
+mkdocs serve 
+


### PR DESCRIPTION
- Checkout this branch and run the `run.sh` file from the root. It may take a while to spin up.
- Go to http://127.0.0.1:8000/ in your browser once it's up.
- You will see in the config the example repos: for example https://github.com/backstage/backstage
- Notice that the plugin assumes a `docs` directory which it pulls the markdown from, and the `mkdocs.yml` config is at the repo root instead.

I will raise a PR in miden-client so we can test it here.

